### PR TITLE
Filter published tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /log/*
 !/log/.keep
 /tmp
+.byebug_history
 
 # ignore app key which contains email user name
 /config/initializers/app_keys.rb

--- a/Gemfile
+++ b/Gemfile
@@ -32,23 +32,11 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem "puma"
+
 gem "meetup_client", github: 'yeeie201/meetup_client'
 
 gem "simple_calendar", "~> 2.0"
-
-group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug'
-end
-
-group :development do
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
-
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-end
-
 
 gem 'bcrypt', '~> 3.1.7'
 gem 'bootstrap-sass', '~> 3.3.6'
@@ -65,8 +53,6 @@ gem 'simple_form'
 gem 'friendly_id'
 gem 'carrierwave', github: 'carrierwaveuploader/carrierwave'
 gem 'mini_magick'
-
-
 gem 'geocoder'
 gem 'underscore-rails'
 gem 'gmaps4rails'
@@ -87,8 +73,15 @@ group :development, :test do
   gem 'faker', github: 'stympy/faker'
   gem 'cowsay'
   gem 'rails-erd'
+  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'byebug'
 end
 
 group :development do
   gem 'letter_opener'
+  # Access an IRB console on exception pages or by using <%= console %> in views
+  gem 'web-console', '~> 2.0'
+
+  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'spring'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,7 @@ GEM
       yard (~> 0.8)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
+    puma (3.4.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
@@ -315,6 +316,7 @@ DEPENDENCIES
   pry-byebug
   pry-doc
   pry-rails
+  puma
   quiet_assets
   rails (= 4.2.6)
   rails-erd
@@ -330,3 +332,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   underscore-rails
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.11.2

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -25,7 +25,7 @@ class OrganizationsController < ApplicationController
     # @organizations = Organization.all  # original
     # @organizations = Organization.paginate(:page => params[:page], :per_page => 3)
 		# TODO: Strech: make unpublished organizations display greyed out
-		 if current_user && current_user.admin?
+		if current_user && current_user.admin?
  			@organizations = Organization.page(params[:page]).per(18)
  		else
      	@organizations = Organization.published.page(params[:page]).per(18)

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -11,6 +11,7 @@ class OrganizationsController < ApplicationController
   end
 
   def show
+
     @claimed = @organization.claim_requests.find_by_status(true)
     hosting_event
       respond_to do |format|
@@ -23,8 +24,12 @@ class OrganizationsController < ApplicationController
   def index
     # @organizations = Organization.all  # original
     # @organizations = Organization.paginate(:page => params[:page], :per_page => 3)
-     @organizations = Organization.page(params[:page]).per(18)
-
+		# TODO: Strech: make unpublished organizations display greyed out
+		 if current_user && current_user.admin?
+ 			@organizations = Organization.page(params[:page]).per(18)
+ 		else
+     	@organizations = Organization.published.page(params[:page]).per(18)
+ 		end
     # respond_to do |format|
       # format.html { render }
       # format.json { render json: @organizations }
@@ -83,7 +88,11 @@ private
 
 
   def find_organization
-    @organization = Organization.find params[:id]
+		if current_user && current_user.admin?
+			@organization = Organization.find params[:id]
+		else
+    	@organization = Organization.published.find params[:id]
+		end
   end
 
   def organization_params

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -30,6 +30,10 @@ class Organization < ActiveRecord::Base
     user ? user.full_name : ""
   end
 
+	def self.published
+		where(published: true)
+	end
+
   private
 
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,8 @@
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
   <script src="//maps.google.com/maps/api/js?v=3.18&sensor=false&client=&key=&libraries=geometry&language=&hl=&region="></script>
-  <script src="//google-maps-utility-library-v3.googlecode.com/svn/tags/markerclustererplus/2.0.14/src/markerclusterer_packed.js"></script>
-  <script src='//google-maps-utility-library-v3.googlecode.com/svn/tags/infobox/1.1.9/src/infobox_packed.js' type='text/javascript'></script> <!-- only if you need custom infoboxes -->
+  <script src="https://cdn.rawgit.com/googlemaps/v3-utility-library/master/markerclustererplus/src/markerclusterer_packed.js"></script>
+  <script src="https://cdn.rawgit.com/googlemaps/v3-utility-library/master/infobox/src/infobox_packed.js"></script>
 </head>
 <body>
     <% if current_user && current_user.admin? %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,11 +83,11 @@ ActiveRecord::Schema.define(version: 20160509020303) do
     t.integer  "user_id"
     t.float    "longitude"
     t.float    "latitude"
-    t.string   "logo"
     t.string   "image"
     t.string   "image2"
     t.string   "image3"
     t.string   "image4"
+    t.string   "logo"
   end
 
   add_index "organizations", ["user_id"], name: "index_organizations_on_user_id", using: :btree

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe OrganizationsController, type: :controller do
      FactoryGirl.attributes_for(:organization).merge({published: true})
    end
 
-   describe "#show" do
+	 describe "#show" do
      describe "as anon user" do
        it "doesn't display unpublished organizations" do
          org = Organization.new(unpublished_attributes)
@@ -31,7 +31,27 @@ RSpec.describe OrganizationsController, type: :controller do
          expect(assigns(:organization)).to eq(org)
        end
      end
-   end
+		 describe "as an admin" do
+		 	it "display unpublished organizations" do
+				org = Organization.new(unpublished_attributes)
+				org.save
+				user = User.new(FactoryGirl.attributes_for(:user).merge({admin: true}))
+				user.save
+				session[:user_id] = user.id
+				get :show, id: org.id
+				expect(assigns(:organization)).to eq(org)
+			end
+			it "display published organizations" do
+				org = Organization.new(published_attributes)
+				org.save
+				user = User.new(FactoryGirl.attributes_for(:user).merge({admin: true}))
+				user.save
+				session[:user_id] = user.id
+				get :show, id: org.id
+				expect(assigns(:organization)).to eq(org)
+		 	end
+		 end
+	 end
 
   describe "#index" do
     describe "as anon user" do
@@ -49,5 +69,25 @@ RSpec.describe OrganizationsController, type: :controller do
        expect(assigns(:organizations)).to include(org)
       end
     end
+		describe "as an admin" do
+			it "does display unpublished organizations on index" do
+				org = Organization.new(unpublished_attributes)
+        org.save
+				user = User.new(FactoryGirl.attributes_for(:user).merge({admin: true}))
+				user.save
+				session[:user_id] = user.id
+        get :index
+        expect(assigns(:organizations)).to include(org)
+			end
+			it "does display published organizations on index" do
+				org = Organization.new(published_attributes)
+        org.save
+				user = User.new(FactoryGirl.attributes_for(:user).merge({admin: true}))
+				user.save
+				session[:user_id] = user.id
+        get :index
+        expect(assigns(:organizations)).to include(org)
+			end
+		end
   end
 end

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -2,4 +2,52 @@ require 'rails_helper'
 
 RSpec.describe OrganizationsController, type: :controller do
 
+   def unpublished_attributes
+      FactoryGirl.attributes_for(:organization).merge({published: false})
+   end
+
+   def published_attributes
+     FactoryGirl.attributes_for(:organization).merge({published: true})
+   end
+
+   describe "#show" do
+     describe "as anon user" do
+       it "doesn't display unpublished organizations" do
+         org = Organization.new(unpublished_attributes)
+         org.save
+         begin
+           get :show, id: org.id
+         rescue
+           puts "not published"
+           puts org
+         end
+         expect(assigns(:organization)).not_to eq(org)
+       end
+
+       it "displays published organizations show page" do
+         org = Organization.new(published_attributes)
+         org.save
+         get :show, id: org.id
+         expect(assigns(:organization)).to eq(org)
+       end
+     end
+   end
+
+  describe "#index" do
+    describe "as anon user" do
+      it "doesn't display unpublished organizations on index" do
+        org = Organization.new(unpublished_attributes)
+        org.save
+        get :index
+        expect(assigns(:organizations)).not_to include(org)
+      end
+
+      it "displays published organizations on index" do
+       org = Organization.new(published_attributes)
+       org.save
+       get :index
+       expect(assigns(:organizations)).to include(org)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Restrict the display of unpublished organizations. Limits both org controller index and show methods. Includes rspec testing.

We also included the byebug history in the git ignore file.

Testing is verbose by intent.
